### PR TITLE
feat: Update jobs to deploy for each network service

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,13 +14,19 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
   deploy:
-    uses: decentraland/dcl-deploy-action@main
     strategy:
       matrix:
         network: [eth, polygon]
         env: [dev, stg]
-    with:
-      dockerImage: "quay.io/decentraland/dapps-substreams-server:${{ github.sha }}"
-      serviceName: "dapps-${{ matrix.network }}-substreams-server"
-      env: ${{ matrix.env }}
-      token: ${{ secrets.GITHUB_TOKEN }}
+    name: "Deploy to: ${{ matrix.env }}"
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.env }}
+    steps:
+      - name: Trigger deployment
+        id: deploy
+        uses: decentraland/dcl-deploy-action@main
+        with:
+          dockerImage: "quay.io/decentraland/dapps-substreams-server:${{ github.sha }}"
+          serviceName: "dapps-${{ matrix.network }}-substreams-server"
+          env: ${{ matrix.env }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,7 +14,6 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
   deploy:
-    id: deploy
     uses: decentraland/dcl-deploy-action@main
     strategy:
       matrix:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,27 @@
+name: CI/CD on main branch
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
+    with:
+      service-name: dapps-substreams-server
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+  deploy:
+    id: deploy
+    uses: decentraland/dcl-deploy-action@main
+    strategy:
+      matrix:
+        network: [eth, polygon]
+        env: [dev, stg]
+    with:
+      dockerImage: "quay.io/decentraland/dapps-substreams-server:${{ github.sha }}"
+      serviceName: "dapps-${{ matrix.network }}-substreams-server"
+      env: ${{ matrix.env }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -1,0 +1,38 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment-environment:
+        required: true
+        type: choice
+        options:
+          - dev
+          - stg
+          - prd
+        default: prd
+        description: Environment
+      tag:
+        required: true
+        default: "latest"
+        type: string
+        description: "Docker tag (quay.io)"
+
+jobs:
+  deployment:
+    if: ${{ inputs.deployment-environment }}
+    name: "Deploy to: ${{ inputs.deployment-environment }}"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.deployment-environment }}
+    strategy:
+      matrix:
+        network: [eth, polygon]
+    steps:
+      - name: Trigger deployment
+        id: deploy
+        uses: decentraland/dcl-deploy-action@main
+        with:
+          dockerImage: "quay.io/decentraland/dapps-substreams-server:${{ inputs.tag }}"
+          serviceName: "dapps-${{ matrix.network }}-substreams-server"
+          env: ${{ inputs.deployment-environment }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,18 @@
-name: CI/CD on main branch
-
+name: Build and publish
 on:
-  push:
-    branches:
-      - 'main'
-
+  release:
+    types:
+      - created
 jobs:
-  cd:
+  build:
+    name: "Build & publish: ${{github.ref_name}}"
     uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
     strategy:
       matrix:
         network: [eth, polygon]
     with:
       service-name: dapps-${{ matrix.network }}-substreams-server
-      deployment-environment: dev stg
+      docker-tag: "${{ github.ref_name }}"
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,8 @@ jobs:
   build:
     name: "Build & publish: ${{github.ref_name}}"
     uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
-    strategy:
-      matrix:
-        network: [eth, polygon]
     with:
-      service-name: dapps-${{ matrix.network }}-substreams-server
+      service-name: dapps-substreams-server
       docker-tag: "${{ github.ref_name }}"
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
We'll have a service dedicated for eth and another for polygon, so this PR updates the workflows so it usas a `matrix` to deploy both services